### PR TITLE
bsps/aarch64/raspberrypi: Refactor BSP for facilitate application layer include

### DIFF
--- a/bsps/aarch64/raspberrypi/console/console.c
+++ b/bsps/aarch64/raspberrypi/console/console.c
@@ -51,54 +51,6 @@
 #include "bsp/aux.h"
 #include "bsp/rpi-gpio.h"
 
-#define CONSOLE_DEVICE_CONTEXT_NAME(port_no) uart##port_no##_context
-
-#define CONSOLE_DEVICE_CONTEXT(port_no, _file_name, base, _size, clock_freq,    \
-                               irq_no, context_type, ...)                       \
-    static context_type CONSOLE_DEVICE_CONTEXT_NAME(port_no) = {                \
-        .context   = RTEMS_TERMIOS_DEVICE_CONTEXT_INITIALIZER("UART" #port_no), \
-        .regs_base = base,                                                      \
-        .clock     = clock_freq,                                                \
-        .initial_baud = BSP_CONSOLE_BAUD,                                       \
-        .irq          = irq_no,                                                 \
-    };
-
-#define CONSOLE_DEVICE(port_no, file_name, _base, _size, _clock, _irq,      \
-                       _context_type, dev_handler, write_char_func, rx_pin, \
-                       tx_pin, gpio_func, ...)                              \
-    [CONSOLE_DEVICE_PORT2ENUM(port_no)] = {                                 \
-        .file    = file_name,                                               \
-        .context = &CONSOLE_DEVICE_CONTEXT_NAME(port_no).context,           \
-        .gpio    = {.rx = rx_pin, .tx = tx_pin, .function = gpio_func},     \
-        .handler = dev_handler,                                             \
-        .write_char_polled = write_char_func,                               \
-    },
-
-typedef struct {
-    const unsigned int rx;
-    const unsigned int tx;
-    const gpio_function function;
-} bsp_console_device_gpio_config;
-
-typedef struct {
-    const char* file;
-    rtems_termios_device_context* context;
-    const bsp_console_device_gpio_config gpio;
-
-    const rtems_termios_device_handler* handler;
-    void (*write_char_polled)(const rtems_termios_device_context*, const char);
-} bsp_console_device;
-
-/* Initialize all console device contexts */
-CONSOLE_DEVICES(CONSOLE_DEVICE_CONTEXT)
-
-/* Initialize all device configurations */
-static const bsp_console_device devices[CONSOLE_DEVICE_COUNT] = {
-    /* clang-format off */
-    CONSOLE_DEVICES(CONSOLE_DEVICE)
-    /* clang-format on */
-};
-
 static rtems_status_code console_device_init_gpio(
     const bsp_console_device_gpio_config* gpio) {
     rtems_status_code status = gpio_set_function(gpio->rx, gpio->function);

--- a/bsps/aarch64/raspberrypi/include/bsp/console.h
+++ b/bsps/aarch64/raspberrypi/include/bsp/console.h
@@ -38,6 +38,8 @@
 #define LIBBSP_AARCH64_RASPBERRYPI_BSP_CONSOLE_H
 
 #include <bspopts.h>
+#include "bsp/aux.h"
+#include "bsp/fatal.h"
 
 #if RTEMS_BSP == raspberrypi4b
 #include "console/raspberrypi4b.def"
@@ -55,5 +57,53 @@ typedef enum {
     CONSOLE_DEVICE_COUNT,
 } bsp_console_device_port;
 #undef CONSOLE_DEVICE_ENUM
+
+#define CONSOLE_DEVICE_CONTEXT_NAME(port_no) uart##port_no##_context
+
+#define CONSOLE_DEVICE_CONTEXT(port_no, _file_name, base, _size, clock_freq,    \
+                               irq_no, context_type, ...)                       \
+    static context_type CONSOLE_DEVICE_CONTEXT_NAME(port_no) = {                \
+        .context   = RTEMS_TERMIOS_DEVICE_CONTEXT_INITIALIZER("UART" #port_no), \
+        .regs_base = base,                                                      \
+        .clock     = clock_freq,                                                \
+        .initial_baud = BSP_CONSOLE_BAUD,                                       \
+        .irq          = irq_no,                                                 \
+    };
+
+#define CONSOLE_DEVICE(port_no, file_name, _base, _size, _clock, _irq,      \
+                       _context_type, dev_handler, write_char_func, rx_pin, \
+                       tx_pin, gpio_func, ...)                              \
+    [CONSOLE_DEVICE_PORT2ENUM(port_no)] = {                                 \
+        .file    = file_name,                                               \
+        .context = &CONSOLE_DEVICE_CONTEXT_NAME(port_no).context,           \
+        .gpio    = {.rx = rx_pin, .tx = tx_pin, .function = gpio_func},     \
+        .handler = dev_handler,                                             \
+        .write_char_polled = write_char_func,                               \
+    },
+
+typedef struct {
+    const unsigned int rx;
+    const unsigned int tx;
+    const gpio_function function;
+} bsp_console_device_gpio_config;
+
+typedef struct {
+    const char* file;
+    rtems_termios_device_context* context;
+    const bsp_console_device_gpio_config gpio;
+
+    const rtems_termios_device_handler* handler;
+    void (*write_char_polled)(const rtems_termios_device_context*, const char);
+} bsp_console_device;
+
+/* Initialize all console device contexts */
+CONSOLE_DEVICES(CONSOLE_DEVICE_CONTEXT)
+
+/* Initialize all device configurations */
+static const bsp_console_device devices[CONSOLE_DEVICE_COUNT] = {
+    /* clang-format off */
+    CONSOLE_DEVICES(CONSOLE_DEVICE)
+    /* clang-format on */
+};
 
 #endif /* LIBBSP_AARCH64_RASPBERRYPI_BSP_CONSOLE_H */


### PR DESCRIPTION
This commit changed the location of device-specific definitions.This will allow adding #include "bsp/console.h" at the application layer to include devices.

The existing device-specific definitions are written in console.c. It is difficult to include in the application layer.I put it in console.h.This will allow adding #include "bsp/console.h" at the application layer to include devices.