### PR TITLE
set_attributes issue & UART FIFO is not enabled correctly

### DIFF
--- a/bsps/shared/dev/serial/pl011.c
+++ b/bsps/shared/dev/serial/pl011.c
@@ -367,7 +367,7 @@ static bool set_attributes(rtems_termios_device_context *base,
         return false;
 
     /* Start mode configuration from a clean slate */
-    uint32_t lcrh = LCRH(regs_base) & LCRH_FEN;
+    uint32_t lcrh = 0;
 
     /* Mode: parity */
     if ((term->c_cflag & PARENB) != 0) {
@@ -427,6 +427,9 @@ static bool set_attributes(rtems_termios_device_context *base,
     /* Set the baudrate */
     IBRD(regs_base) = ibrd;
     FBRD(regs_base) = fbrd;
+
+    /* enable FIFO */
+    lcrh = lcrh | LCRH_FEN;
 
     /*
      * Commit mode configurations

--- a/bsps/shared/dev/serial/pl011.c
+++ b/bsps/shared/dev/serial/pl011.c
@@ -157,8 +157,8 @@ static void flush_fifos(const pl011_context *context) {
     const uintptr_t regs_base = context->regs_base;
 
     /* Wait for pending transactions */
-    while ((FR(regs_base) & FR_BUSY) != 0)
-        ;
+    // while ((FR(regs_base) & FR_BUSY) != 0)
+    //     ;
 
     LCRH(regs_base) &= ~LCRH_FEN;
     LCRH(regs_base) |= LCRH_FEN;


### PR DESCRIPTION
I checked the lcrh register and the FEN bit is not set ,  FIFO is not enabled correctly.