### PR TITLE
fix: UART issue & interrupt mode issue

### DIFF
--- a/bsps/shared/dev/serial/pl011.c
+++ b/bsps/shared/dev/serial/pl011.c
@@ -363,7 +363,7 @@ static bool set_attributes(rtems_termios_device_context *base,
         return false;
 
     /* Start mode configuration from a clean slate */
-    uint32_t lcrh = LCRH(regs_base) & LCRH_FEN;
+    uint32_t lcrh = 0;
 
     /* Mode: parity */
     if ((term->c_cflag & PARENB) != 0) {
@@ -423,6 +423,9 @@ static bool set_attributes(rtems_termios_device_context *base,
     /* Set the baudrate */
     IBRD(regs_base) = ibrd;
     FBRD(regs_base) = fbrd;
+
+    /* enable FIFO */
+    lcrh = lcrh | LCRH_FEN;
 
     /*
      * Commit mode configurations

--- a/bsps/shared/dev/serial/pl011.c
+++ b/bsps/shared/dev/serial/pl011.c
@@ -155,11 +155,7 @@ static inline bool is_txfifo_full(const uintptr_t regs_base) {
 
 static void flush_fifos(const pl011_context *context) {
     const uintptr_t regs_base = context->regs_base;
-
-    /* Wait for pending transactions */
-    while ((FR(regs_base) & FR_BUSY) != 0)
-        ;
-
+    
     LCRH(regs_base) &= ~LCRH_FEN;
     LCRH(regs_base) |= LCRH_FEN;
 }


### PR DESCRIPTION
1. set_attributes issue
- https://discord.com/channels/820452222382112799/822225822508908585/1180421668502511706
- Calling set_attributes() will cause the program to be blocked.

2. fifo is not enabled
- I checked the lcrh register and the FEN bit is not set , FIFO is not enabled correctly.

3. fix: In UART interrupt mode, writing a large number of characters will cause fatal
- It seems that if the second parameter passed to rtems_termios_dequeue_characters() is 0, it will cause a PC alignment fault ? 
- When write_buffer writes the first character, if txfifo is full, it will return directly.
This will cause this character to be lost.
so, I made the following changes: When the write_buffer() writes the first character, if txfifo is full, wait for it to be not full. 
- https://discord.com/channels/820452222382112799/820452222848335924/1230042008639373353

5. about UART interrupt mode RX.
https://discord.com/channels/820452222382112799/820452222848335924/1230491915376656535
read() or scanf() is not blocking in interrupt mode. it works fine in poll mode.
I solved it through the following code. I don’t know if it is a termios bug.
```c
  struct termios term;
  tcgetattr(STDIN_FILENO, &term);
  tcsetattr(STDIN_FILENO, TCSANOW, &term);
```